### PR TITLE
Fixed some stack overflow exceptions due to recursions

### DIFF
--- a/src/main/java/net/gtaun/shoebill/entities/impl/PlayerAttachImpl.kt
+++ b/src/main/java/net/gtaun/shoebill/entities/impl/PlayerAttachImpl.kt
@@ -64,7 +64,7 @@ class PlayerAttachImpl internal constructor(override val player: Player) : Playe
                 .append("modelId", modelId).toString()
 
         override val player: Player
-            get() = player
+            get() = this@PlayerAttachImpl.player
 
         override fun set(bone: PlayerAttachBone, modelId: Int, offset: Vector3D, rotation: Vector3D, scale: Vector3D,
                          materialColor1: Int, materialColor2: Int): Boolean {

--- a/src/main/java/net/gtaun/shoebill/entities/impl/PlayerLabelImpl.kt
+++ b/src/main/java/net/gtaun/shoebill/entities/impl/PlayerLabelImpl.kt
@@ -86,7 +86,6 @@ constructor(val eventManager: EventManager, val store: SampObjectStoreImpl, over
 
     override val isDestroyed: Boolean
         get() {
-            if (!player.isOnline && id != PlayerLabel.INVALID_ID) destroy()
             return id == PlayerLabel.INVALID_ID
         }
 

--- a/src/main/java/net/gtaun/shoebill/entities/impl/PlayerObjectImpl.kt
+++ b/src/main/java/net/gtaun/shoebill/entities/impl/PlayerObjectImpl.kt
@@ -90,7 +90,6 @@ constructor(store: SampObjectStoreImpl, override val player: Player, override va
 
     override val isDestroyed: Boolean
         get() {
-            if (!player.isOnline && id != PlayerObject.INVALID_ID) destroy()
             return id == PlayerObject.INVALID_ID
         }
 

--- a/src/main/java/net/gtaun/shoebill/entities/impl/PlayerTextdrawImpl.kt
+++ b/src/main/java/net/gtaun/shoebill/entities/impl/PlayerTextdrawImpl.kt
@@ -172,7 +172,6 @@ constructor(private val rootEventManager: EventManager, override val player: Pla
 
     override val isDestroyed: Boolean
         get() {
-            if (!player.isOnline && id != PlayerTextdraw.INVALID_ID) destroy()
             return id == PlayerTextdraw.INVALID_ID
         }
 


### PR DESCRIPTION
I discovered some recursions that will lead to stack overflow exceptions; if objects, labels or textdraws are destroyed when the player disconnects, this will lead to an infinite loop